### PR TITLE
Remove required Google Cloud config; fix docker-compose for fresh deploys

### DIFF
--- a/MULTI_TENANT_TODO.md
+++ b/MULTI_TENANT_TODO.md
@@ -1,0 +1,70 @@
+# Future: self-serve multi-tenant platform on Reclaim Cloud
+
+Status: not started — planning placeholder on branch `feature/multi-tenant-self-serve`.
+
+## Goal
+
+Let other professors run their own classes on Kyle's single Reclaim Cloud
+deployment, with **minimal setup input** from the professor. Today's setup
+requires per-deployment Google Cloud plumbing that only makes sense for one
+person running one instance — it does not scale to "many professors, one
+shared server."
+
+> Direct ask: "It should require minimal inputs by the prof using the
+> system -- I had way too much extra crap."
+
+## Why today's model doesn't scale
+
+Every app reads its config from environment variables. A single instance
+today needs all of these set:
+
+| Env var | Used by | Purpose |
+|---|---|---|
+| `GOOGLE_SERVICE_ACCOUNT_JSON` / `GOOGLE_APPLICATION_CREDENTIALS` | class-job-picker, coordination-games, flex_pass_actions, price-index, supply-auction-game | Google service-account auth |
+| `FLEX_PASS_SHEET_ID` | coordination-games, flex_pass_actions | Credentials Google Sheet |
+| `FLEX_PASS_FOLDER_ID` | coordination-games, flex_pass_actions, price-index, supply-auction-game | Drive backup folder |
+| `AUCTION_FOLDER_ID` | supply-auction-game | Drive backup folder |
+| `CLASS_JOB_SHEET_ID` | class-job-picker | Summary write-back sheet |
+| `PUB_ECON_FOLDER_ID`, `FINALQ_SHEET_ID`, `CRED_CSV`, `CRED_PATH` | flex_pass_actions | Legacy credential sources |
+| `DB_PATH_OVERRIDE` | coordination-games | DB path override |
+| `SHINY_PASSWORD` | bonus-entry, class-job-picker, club-insurance-game | Shared admin password |
+| `CONNECT_CONTENT_DIR` | nearly every app | Where the shared `data/` dir lives |
+
+A second professor would need their **own** Google Cloud project, service
+account, credentials Sheet, and Drive folder just to get an instance running.
+That's the "extra crap" to design away.
+
+## Target shape (rough — not final)
+
+- One shared Reclaim Cloud deployment, one shared DB (or one DB per tenant —
+  TBD), serving multiple classes.
+- A `class`/`tenant` concept: every row in `users`, `sections`, `ledger`,
+  `job_log`, etc. scoped by `class_id`. This extends the same pattern as the
+  `active` flag added for archiving prior semesters (see git history on
+  `main` around the `final_question_reveal` → `flex_pass_actions` rename) —
+  every per-app login query and admin dropdown needs the same `class_id`
+  scoping treatment across all 7 apps that touch `users`.
+- Professor onboarding without Google Cloud: sign up → name a class → get an
+  admin login, instantly. No service account, no Sheet ID, no Folder ID.
+- Backups become Kyle's own ops concern (one centralized backup job for the
+  whole server), not a per-professor Google Drive integration.
+- Each professor's admin view/queries scoped to their own class only — must
+  not see or manage another professor's roster.
+
+## Open questions to resolve before building
+
+- SQLite (file-per-tenant?) vs. moving to Postgres for safer concurrent
+  multi-tenant writes.
+- How a new professor actually signs up — invite-only (Kyle approves) vs.
+  fully self-serve.
+- What happens to the existing Google Sheets/Drive-based credential and
+  backup flow for Kyle's own classes — keep as a legacy path, or migrate
+  everyone (including Kyle) to the new model?
+- Whether `SHINY_PASSWORD`-style shared admin passwords (bonus-entry,
+  club-insurance-game) need the same per-class scoping or can stay global.
+
+## Non-goal for now
+
+This file exists to hold the idea so it isn't lost — no code changes yet.
+Pick this up deliberately, scope a first milestone, and confirm the design
+direction before implementing.

--- a/MULTI_TENANT_TODO.md
+++ b/MULTI_TENANT_TODO.md
@@ -1,6 +1,23 @@
 # Future: self-serve multi-tenant platform on Reclaim Cloud
 
-Status: not started — planning placeholder on branch `feature/multi-tenant-self-serve`.
+Status: tenant isolation (the `class_id` data model below) — not started.
+First milestone — **removing required Google Cloud config for normal
+operation** — done on this branch:
+
+- `flex_pass_actions/app.R`: a brand-new deployment with an empty DB and no
+  Google Sheets configured can now bootstrap its first admin account via
+  `BOOTSTRAP_ADMIN_USER` / `BOOTSTRAP_ADMIN_PASSWORD` instead of hard-failing.
+- `supply-auction-game/app.R`: no longer requires `FLEX_PASS_FOLDER_ID` /
+  Google Drive for login — it reads the shared `users` table directly from
+  `finalqdata.sqlite`, same as every other app. Fixes the credential
+  staleness lag as a side effect.
+- `GOOGLE_SERVICE_ACCOUNT_JSON`/`GOOGLE_APPLICATION_CREDENTIALS`,
+  `FLEX_PASS_SHEET_ID`, `FLEX_PASS_FOLDER_ID`, `AUCTION_FOLDER_ID`,
+  `CLASS_JOB_SHEET_ID` are now fully optional everywhere — see the root
+  `README.md` Deployment section for the current required-vs-optional list.
+
+The `class`/tenant scoping work below is still not started — that's the
+next, larger milestone, deliberately kept separate from this one.
 
 ## Goal
 
@@ -22,7 +39,7 @@ today needs all of these set:
 |---|---|---|
 | `GOOGLE_SERVICE_ACCOUNT_JSON` / `GOOGLE_APPLICATION_CREDENTIALS` | class-job-picker, coordination-games, flex_pass_actions, price-index, supply-auction-game | Google service-account auth |
 | `FLEX_PASS_SHEET_ID` | coordination-games, flex_pass_actions | Credentials Google Sheet |
-| `FLEX_PASS_FOLDER_ID` | coordination-games, flex_pass_actions, price-index, supply-auction-game | Drive backup folder |
+| `FLEX_PASS_FOLDER_ID` | coordination-games, flex_pass_actions, price-index | Drive backup folder (optional) |
 | `AUCTION_FOLDER_ID` | supply-auction-game | Drive backup folder |
 | `CLASS_JOB_SHEET_ID` | class-job-picker | Summary write-back sheet |
 | `PUB_ECON_FOLDER_ID`, `FINALQ_SHEET_ID`, `CRED_CSV`, `CRED_PATH` | flex_pass_actions | Legacy credential sources |

--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
 Shiny apps I build largely for classroom use.
+
+## Deployment
+
+`docker-compose up --build` (see `docker-compose.yml`, `Dockerfile`,
+`Dockerfile.base`) runs every app under one Shiny Server container, sharing
+one `data/finalqdata.sqlite` (mounted via the `appdata` volume).
+
+**Nothing is required to get a working deployment.** On first boot with an
+empty database, set these two env vars once to create your own admin login,
+then unset them — every later boot uses the account already in the DB:
+
+- `BOOTSTRAP_ADMIN_USER`
+- `BOOTSTRAP_ADMIN_PASSWORD`
+- `BOOTSTRAP_ADMIN_NAME` (optional display name; defaults to the username)
+
+Once you have an admin account, manage the whole roster from the
+`flex_pass_actions` app's Admin tab (create/archive/restore users, reset
+passwords, grant flex passes) — no further configuration needed.
+
+Everything else is **optional**, for legacy/extra functionality only:
+
+| Env var | Used by | What it enables |
+|---|---|---|
+| `GOOGLE_SERVICE_ACCOUNT_JSON` / `GOOGLE_APPLICATION_CREDENTIALS` | class-job-picker, coordination-games, flex_pass_actions, price-index, supply-auction-game | Google Drive backups + Sheets sync |
+| `FLEX_PASS_SHEET_ID` | coordination-games, flex_pass_actions | Manage the roster via a Google Sheet instead of the in-app admin panel |
+| `FLEX_PASS_FOLDER_ID` | coordination-games, flex_pass_actions, price-index | Off-site Drive backup of the shared DB |
+| `AUCTION_FOLDER_ID` | supply-auction-game | Off-site Drive backup of the auction DB |
+| `CLASS_JOB_SHEET_ID` | class-job-picker | One-off historical import / summary write-back to Sheets |
+| `PUB_ECON_FOLDER_ID`, `FINALQ_SHEET_ID`, `CRED_CSV`, `CRED_PATH` | flex_pass_actions | Legacy alternate credential sources |
+| `DB_PATH_OVERRIDE` | coordination-games | Override the shared DB path |
+| `SHINY_PASSWORD` | bonus-entry, class-job-picker, club-insurance-game | Shared admin password for those apps |
+| `CONNECT_CONTENT_DIR` | nearly every app | Where the shared `data/` dir lives (set once for the whole container) |
+
+See `MULTI_TENANT_TODO.md` for the (not yet started) plan to let other
+professors run their own classes on one shared deployment.

--- a/README.md
+++ b/README.md
@@ -6,9 +6,18 @@ Shiny apps I build largely for classroom use.
 `Dockerfile.base`) runs every app under one Shiny Server container, sharing
 one `data/finalqdata.sqlite` (mounted via the `appdata` volume).
 
-**Nothing is required to get a working deployment.** On first boot with an
-empty database, set these two env vars once to create your own admin login,
-then unset them — every later boot uses the account already in the DB:
+**One env var is required**, because each app's own directory under
+`/srv/shiny-server/` is root-owned and not writable by the `shiny` user —
+without this, apps can't even create their local SQLite file and 500 on
+first request:
+
+- `CONNECT_CONTENT_DIR=/srv/shiny-server/appdata` — point every app at the
+  writable, volume-mounted `appdata` directory instead of its own
+  read-only source folder. Set this once for the whole container.
+
+On first boot with an empty database, also set these two env vars once to
+create your own admin login, then unset them — every later boot uses the
+account already in the DB:
 
 - `BOOTSTRAP_ADMIN_USER`
 - `BOOTSTRAP_ADMIN_PASSWORD`
@@ -30,7 +39,6 @@ Everything else is **optional**, for legacy/extra functionality only:
 | `PUB_ECON_FOLDER_ID`, `FINALQ_SHEET_ID`, `CRED_CSV`, `CRED_PATH` | flex_pass_actions | Legacy alternate credential sources |
 | `DB_PATH_OVERRIDE` | coordination-games | Override the shared DB path |
 | `SHINY_PASSWORD` | bonus-entry, class-job-picker, club-insurance-game | Shared admin password for those apps |
-| `CONNECT_CONTENT_DIR` | nearly every app | Where the shared `data/` dir lives (set once for the whole container) |
 
 See `MULTI_TENANT_TODO.md` for the (not yet started) plan to let other
 professors run their own classes on one shared deployment.

--- a/apps/flex_pass_actions/app.R
+++ b/apps/flex_pass_actions/app.R
@@ -830,8 +830,27 @@ CRED <- tryCatch(
       logf("Loaded", nrow(rows), "users from DB fallback (Google Sheets unavailable)")
       rows
     } else {
-      stop("No credentials available. Google Sheets error: ", conditionMessage(e),
-           " | DB also empty or unavailable.")
+      # Zero-config bootstrap: lets a brand-new deployment (empty DB, no
+      # Google Sheets configured) create its first admin account without
+      # any Google Cloud setup at all. Once that admin exists, every
+      # future restart hits the DB fallback above instead.
+      boot_user <- Sys.getenv("BOOTSTRAP_ADMIN_USER", "")
+      boot_pw   <- Sys.getenv("BOOTSTRAP_ADMIN_PASSWORD", "")
+      if (nzchar(boot_user) && nzchar(boot_pw)) {
+        logf("Bootstrapping first admin account from BOOTSTRAP_ADMIN_USER/PASSWORD:", boot_user)
+        data.frame(
+          user     = boot_user,
+          name     = Sys.getenv("BOOTSTRAP_ADMIN_NAME", boot_user),
+          pw_hash  = bcrypt::hashpw(boot_pw),
+          is_admin = TRUE,
+          stringsAsFactors = FALSE
+        )
+      } else {
+        stop("No credentials available. Google Sheets error: ", conditionMessage(e),
+             " | DB also empty or unavailable.",
+             " | To bootstrap a fresh deployment without Google Sheets, set",
+             " BOOTSTRAP_ADMIN_USER and BOOTSTRAP_ADMIN_PASSWORD.")
+      }
     }
   }
 )

--- a/apps/supply-auction-game/app.R
+++ b/apps/supply-auction-game/app.R
@@ -25,15 +25,12 @@ logf <- function(...) {
 
 APP_CONFIG <- list(
   folder_id      = Sys.getenv("AUCTION_FOLDER_ID", ""),      # Drive folder for THIS auction app backups
-  flex_folder_id = Sys.getenv("FLEX_PASS_FOLDER_ID", ""),     # Drive folder where flex_pass_actions backups live
-  cred_db_path   = "finalqdata_latest_backup.zip",
   gsa_json       = Sys.getenv("GOOGLE_SERVICE_ACCOUNT_JSON", ""),
   gsa_path       = Sys.getenv("GOOGLE_APPLICATION_CREDENTIALS", "")
 )
 
 logf("CONFIG:",
      "AUCTION_FOLDER_ID present:", nzchar(APP_CONFIG$folder_id),
-     "| FLEX_PASS_FOLDER_ID present:", nzchar(APP_CONFIG$flex_folder_id),
      "| gsa_json present:", nzchar(APP_CONFIG$gsa_json),
      "| gsa_path:", APP_CONFIG$gsa_path)
 
@@ -91,10 +88,8 @@ google_auth <- function() {
 }
 
 drive_folder_id <- function() APP_CONFIG$folder_id
-flex_folder_id  <- function() APP_CONFIG$flex_folder_id
 
 latest_zip_name <- function() "auction_latest_backup.zip"
-FLEX_LATEST_ZIP <- APP_CONFIG$cred_db_path
 
 # ---- Drive helpers ----
 drive_ls_with_times <- function(folder_id) {
@@ -229,33 +224,27 @@ restore_db_from_drive <- function(filename = latest_zip_name()) {
   TRUE
 }
 
-# ---- Credentials: READ ONLY from flex-pass game Drive snapshot ----
-read_credentials_from_flex_snapshot <- function() {
-  if (!google_auth()) stop("read_credentials_from_flex_snapshot(): google_auth() failed")
-  folder <- flex_folder_id()
-  if (!nzchar(folder)) stop("read_credentials_from_flex_snapshot(): FLEX_PASS_FOLDER_ID not set")
+# ---- Credentials: read directly from the shared finalqdata.sqlite ----
+# Every other app in this monorepo (price-index, class-job-picker, etc.)
+# reads `users` straight from the shared DB instead of via a Drive backup.
+# Doing the same here removes the hard Google Drive dependency for login
+# and the staleness lag of waiting on the next snapshot.
+SHARED_DB_PATH <- local({
+  root <- Sys.getenv("CONNECT_CONTENT_DIR", unset = {
+    # local dev: walk up to sibling app directory
+    file.path(dirname(normalizePath(getwd())), "flex_pass_actions")
+  })
+  file.path(root, "data", "finalqdata.sqlite")
+})
 
-  info <- pick_latest_file_id(folder, FLEX_LATEST_ZIP)
-  if (!nzchar(info$id) || is.na(info$id)) stop("No credentials snapshot found named ", FLEX_LATEST_ZIP)
-
-  zipfile <- file.path(tempdir(), FLEX_LATEST_ZIP)
-  googledrive::drive_download(file = info$id, path = zipfile, overwrite = TRUE)
-
-  exdir <- file.path(tempdir(), paste0("flexcred_", as.integer(Sys.time())))
-  dir.create(exdir, recursive = TRUE, showWarnings = FALSE)
-  utils::unzip(zipfile, exdir = exdir)
-
-  dbs <- list.files(exdir, pattern = "\\.sqlite$", full.names = TRUE, recursive = TRUE)
-  if (!length(dbs)) stop("Could not find any .sqlite inside ", FLEX_LATEST_ZIP)
-
-  cred_db <- dbs[1]
-  con <- DBI::dbConnect(RSQLite::SQLite(), cred_db)
+read_shared_users <- function() {
+  con <- DBI::dbConnect(RSQLite::SQLite(), SHARED_DB_PATH)
   on.exit(try(DBI::dbDisconnect(con), silent = TRUE), add = TRUE)
 
   cols <- DBI::dbGetQuery(con, "PRAGMA table_info(users);")
   need <- c("user_id", "display_name", "pw_hash", "is_admin")
   if (!all(need %in% cols$name)) {
-    stop("Credentials DB users table missing columns: ", paste(setdiff(need, cols$name), collapse = ", "))
+    stop("Shared users table missing columns: ", paste(setdiff(need, cols$name), collapse = ", "))
   }
 
   has_active <- "active" %in% cols$name
@@ -271,8 +260,8 @@ read_credentials_from_flex_snapshot <- function() {
       active = if (has_active) ifelse(is.na(active), 1L, as.integer(active)) else 1L
     )
 
-  logf("Users in credentials DB: ", paste(u$user_id, collapse = ", "))
-  list(users = u, snapshot_when = info$when %||% NA_character_)
+  logf("Users in shared DB: ", paste(u$user_id, collapse = ", "))
+  list(users = u, snapshot_when = format(Sys.time(), "%Y-%m-%d %H:%M:%S"))
 }
 
 # ---- SQLite connection (auction db) ----
@@ -519,13 +508,13 @@ server <- function(input, output, session) {
   # Ensure schema exists
   init_db()
 
-  # Load credentials from flex snapshot
+  # Load credentials from the shared finalqdata.sqlite
   cred_cache <- reactiveValues(users = NULL, when = NA_character_)
   refresh_creds <- function() {
-    out <- read_credentials_from_flex_snapshot()
+    out <- read_shared_users()
     cred_cache$users <- out$users
     cred_cache$when  <- out$snapshot_when
-    logf("Loaded credentials:", nrow(out$users), "| snapshot when:", out$snapshot_when %||% "NA")
+    logf("Loaded credentials:", nrow(out$users), "| fetched at:", out$snapshot_when %||% "NA")
   }
   tryCatch(refresh_creds(), error = function(e) {
     logf("Credential load failed:", conditionMessage(e))
@@ -587,7 +576,7 @@ server <- function(input, output, session) {
             h3("Clock Auction"),
             p(class="muted",
               "Price ticks up automatically. Click 'Accept' if you're willing to buy one unit at the current price."),
-            p(class="muted", paste0("Credentials snapshot time: ", cred_cache$when %||% "NA")),
+            p(class="muted", paste0("Roster last loaded: ", cred_cache$when %||% "NA")),
             if (!drive_enabled()) p(class="muted", "Drive backups: OFF (local dev / missing env vars)"),
             if (drive_enabled())  p(class="muted", "Drive backups: ON (backup occurs on Accept/Start/Stop/Round/Manual)"),
             uiOutput("auction_status"),
@@ -766,7 +755,7 @@ server <- function(input, output, session) {
           br(), br(),
           actionButton("reset_btn", "RESET auction (clears accepts + resets state)", class="btn-danger"),
           br(), br(),
-          actionButton("refresh_creds", "Refresh credentials from FLEX snapshot", class="btn-default"),
+          actionButton("refresh_creds", "Refresh roster from shared database", class="btn-default"),
           verbatimTextOutput("admin_msg")
         )
       )
@@ -869,7 +858,7 @@ server <- function(input, output, session) {
     req(authed(), is_admin())
     tryCatch({
       refresh_creds()
-      admin_msg(paste0("Refreshed credentials. Snapshot time: ", cred_cache$when %||% "NA"))
+      admin_msg(paste0("Refreshed roster. Loaded at: ", cred_cache$when %||% "NA"))
     }, error = function(e) admin_msg(paste0("ERROR: ", conditionMessage(e))))
   })
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,18 @@
 services:
   shiny:
     image: ghcr.io/kgcsport/shiny-apps:latest
+    build: .
     restart: always
     ports:
       - "80:3838"
     volumes:
-      - ./google_application_credentials.json:/run/secrets/gcp.json:ro
+      # Optional: only needed if you want Google Drive backups/Sheets sync
+      # via a credentials *file*. Simpler alternative: set
+      # GOOGLE_SERVICE_ACCOUNT_JSON (the raw JSON content) in .env instead —
+      # no file or mount required. Uncomment below if you specifically want
+      # the file-based path and have google_application_credentials.json
+      # in this directory:
+      # - ./google_application_credentials.json:/run/secrets/gcp.json:ro
       - ./appdata:/srv/shiny-server/appdata
       - ./shiny-server.conf:/etc/shiny-server/shiny-server.conf:ro
       - ./shiny-logs:/var/log/shiny-server


### PR DESCRIPTION
## Summary
- flex_pass_actions can bootstrap its first admin account via BOOTSTRAP_ADMIN_USER/BOOTSTRAP_ADMIN_PASSWORD instead of requiring Google Sheets on a fresh DB.
- supply-auction-game reads the shared users table directly instead of via a Google Drive snapshot, removing a hard Drive dependency and a staleness lag.
- docker-compose.yml no longer mounts a credentials file that may not exist; adds a build section so `--build` actually rebuilds from source.
- README documents required vs. optional env vars; CONNECT_CONTENT_DIR corrected to required for the Docker deployment.
- Smoke-tested locally end to end (build + run with only BOOTSTRAP_ADMIN_USER/PASSWORD set, confirmed admin row created with valid bcrypt hash, confirmed supply-auction-game boots without Drive).
- Adds MULTI_TENANT_TODO.md tracking the (separate, not-started) future multi-tenant milestone.

## Test plan
- [x] Parsed every changed R file
- [x] Local docker compose build + up smoke test
- [ ] Pull on the Reclaim Cloud host and confirm existing roster/login still works